### PR TITLE
Fix MinutesInVoiceChannel formatting

### DIFF
--- a/src/Accord.Bot/CommandGroups/XpCommandGroup.cs
+++ b/src/Accord.Bot/CommandGroups/XpCommandGroup.cs
@@ -52,7 +52,7 @@ namespace Accord.Bot.CommandGroups
             stringBuilder.AppendLine("**Voice Minutes**");
 
             var voiceUsers = string.Join(Environment.NewLine, leaderboard.VoiceUsers
-                .Select(x => $"{DiscordMentionHelper.UserIdToMention(x.DiscordUserId)} {x.MinutesInVoiceChannel}"));
+                .Select(x => $"{DiscordMentionHelper.UserIdToMention(x.DiscordUserId)} {x.MinutesInVoiceChannel:0.00}"));
 
             stringBuilder.Append(voiceUsers);
 


### PR DESCRIPTION
The voice minutes embed sometimes shows the value with some floating-point errors leading to immeasurably large numbers popping in the embed. 

![image](https://user-images.githubusercontent.com/16415180/122617204-15857a00-d08c-11eb-9669-432a893a741f.png)

This PR fixes the problem by imposing a `0.00` format, with strictly two decimal places being shown for each value.