### PR TITLE
Add a permission to bypass raid detection

### DIFF
--- a/src/Accord.Domain/Model/Permission.cs
+++ b/src/Accord.Domain/Model/Permission.cs
@@ -26,6 +26,7 @@ namespace Accord.Domain.Model
         ManageUserReports = 1,
         ManagePatterns = 2,
         ListRiskyUsers = 3,
+        BypassRaidCheck = 4
     }
 
     public class UserPermissionEntityTypeConfiguration : IEntityTypeConfiguration<UserPermission>

--- a/src/Accord.Services/Permissions/AddPermission.cs
+++ b/src/Accord.Services/Permissions/AddPermission.cs
@@ -39,7 +39,7 @@ namespace Accord.Services.Permissions
 
             await _db.SaveChangesAsync(cancellationToken);
 
-            await _mediator.Send(new InvalidateUserHasPermissionRequest(request.DiscordUserId), cancellationToken);
+            await _mediator.Publish(new PermissionsUpdateNotification(request.DiscordUserId), cancellationToken);
 
             return ServiceResponse.Ok();
         }

--- a/src/Accord.Services/Permissions/UserHasPermission.cs
+++ b/src/Accord.Services/Permissions/UserHasPermission.cs
@@ -12,9 +12,9 @@ using Microsoft.EntityFrameworkCore;
 namespace Accord.Services.Permissions
 {
     public sealed record UserHasPermissionRequest(PermissionUser User, PermissionType Permission) : IRequest<bool>;
-    public sealed record InvalidateUserHasPermissionRequest(ulong UserId) : IRequest;
+    public sealed record PermissionsUpdateNotification(ulong UserId) : INotification;
 
-    public class UserHasPermission : RequestHandler<InvalidateUserHasPermissionRequest>, IRequestHandler<UserHasPermissionRequest, bool>
+    public class UserHasPermission : NotificationHandler<PermissionsUpdateNotification>, IRequestHandler<UserHasPermissionRequest, bool>
     {
         private readonly AccordContext _db;
         private readonly IAppCache _appCache;
@@ -34,7 +34,7 @@ namespace Accord.Services.Permissions
             return permissions.Any(ownedPermission => ownedPermission == request.Permission);
         }
 
-        protected override void Handle(InvalidateUserHasPermissionRequest request)
+        protected override void Handle(PermissionsUpdateNotification request)
         {
             _appCache.Remove(BuildGetPermissionsForUserCacheKey(request.UserId));
         }

--- a/src/Accord.Services/Permissions/UserIsExemptFromRaid.cs
+++ b/src/Accord.Services/Permissions/UserIsExemptFromRaid.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Accord.Domain;
+using Accord.Domain.Model;
+using LazyCache;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Accord.Services.Permissions
+{
+    public sealed record UserIsExemptFromRaidRequest(ulong UserId) : IRequest<bool>;
+
+    public class UserIsExemptFromRaid : NotificationHandler<PermissionsUpdateNotification>, IRequestHandler<UserIsExemptFromRaidRequest, bool>
+    {
+        private static readonly string AllowlistedUsersCacheKey = $"{nameof(UserIsExemptFromRaid)}/{nameof(GetAllowlistedUsers)}";
+        private readonly AccordContext _db;
+        private readonly IAppCache _appCache;
+
+        public UserIsExemptFromRaid(AccordContext db, IAppCache appCache)
+        {
+            _db = db;
+            _appCache = appCache;
+        }
+
+        public async Task<bool> Handle(UserIsExemptFromRaidRequest request, CancellationToken cancellationToken)
+        {
+            var allowedUsers = await _appCache.GetOrAddAsync(AllowlistedUsersCacheKey,
+                () => GetAllowlistedUsers(),
+                DateTimeOffset.Now.AddHours(1));
+
+            return allowedUsers.Contains(request.UserId);
+        }
+
+        protected override void Handle(PermissionsUpdateNotification request)
+        {
+            _appCache.Remove(AllowlistedUsersCacheKey);
+        }
+
+        private async Task<List<ulong>> GetAllowlistedUsers()
+        {
+            return await _db.Permissions
+                .OfType<UserPermission>()
+                .Where(x => x.Type == PermissionType.BypassRaidCheck)
+                .Select(x => x.UserId)
+                .ToListAsync();
+        }
+    }
+}

--- a/src/Accord.Services/Raid/RaidCalculation.cs
+++ b/src/Accord.Services/Raid/RaidCalculation.cs
@@ -1,8 +1,11 @@
-﻿using System.Threading;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Accord.Domain;
 using Accord.Domain.Model;
 using Accord.Services.Moderation;
+using Accord.Services.Permissions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -26,6 +29,12 @@ namespace Accord.Services.Raid
 
         public async Task<ServiceResponse> Handle(RaidCalculationRequest request, CancellationToken cancellationToken)
         {
+            var bypassRaidCheck = await _mediator.Send(new UserIsExemptFromRaidRequest(request.User.Id), cancellationToken);
+            if (bypassRaidCheck)
+            {
+                return ServiceResponse.Ok();
+            }
+
             var sequentialLimit = await _mediator.Send(new GetJoinLimitPerMinuteRequest(), cancellationToken);
             var accountCreationLimit = await _mediator.Send(new GetAccountCreationSimilarityLimitRequest(), cancellationToken);
 


### PR DESCRIPTION
Adds a "BypassRaidCheck" user permission and skips the raid detection if that's set.
I also update InvalidateUserHasPermissionRequest to be a notification so it's a multicast event.
I went with adding a new handler for this so it has its own cache of users with the permission rather than caching for each user. That way it'll do one big request infrequently, instead of needing to hit the db on each user join.

I haven't verified the functionality myself because I don't have multiple accounts, but I did verify that the bot at least runs correctly and loads the cache into memory. There's also no tests project :(

