### PR TITLE
Add API*, ASP*, BL*, MVC* to `/lookup`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.14.0" />
     <PackageVersion Include="MediatR" Version="12.5.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.App.Ref" Version="10.0.9" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" />

--- a/src/Accord.DiagnosticsHarvester/Accord.DiagnosticsHarvester.csproj
+++ b/src/Accord.DiagnosticsHarvester/Accord.DiagnosticsHarvester.csproj
@@ -16,5 +16,7 @@
     <None Include="$(PkgMicrosoft_CodeAnalysis_CSharp_CodeStyle)\analyzers\dotnet\**\*.dll" CopyToOutputDirectory="PreserveNewest" LinkBase="analyzers\codestyle" />
     <!-- dotnet\**\*.dll would include localized resources, only use top-level analyzers (App.Analyzers, Components.Analyzers). -->
     <None Include="$(PkgMicrosoft_AspNetCore_App_Ref)\analyzers\dotnet\cs\*.dll" CopyToOutputDirectory="PreserveNewest" LinkBase="analyzers\aspnetcore" />
+    <!-- MVC*/API* analyzers ship only in the Web SDK. The Web SDK is included with every .NET SDK. -->
+    <None Include="$(MSBuildSDKsPath)\Microsoft.NET.Sdk.Web\analyzers\cs\*.dll" CopyToOutputDirectory="PreserveNewest" LinkBase="analyzers\websdk" />
   </ItemGroup>
 </Project>

--- a/src/Accord.DiagnosticsHarvester/Accord.DiagnosticsHarvester.csproj
+++ b/src/Accord.DiagnosticsHarvester/Accord.DiagnosticsHarvester.csproj
@@ -1,14 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- AD0001: 'Analyzer Failure'
+         Emitted by Microsoft.AspNetCore.App.Ref due to missing ASP runtime types (which we don't need). -->
+    <NoWarn>$(NoWarn);AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" GeneratePathProperty="true" PrivateAssets="all" ExcludeAssets="analyzers" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" GeneratePathProperty="true" PrivateAssets="all" ExcludeAssets="analyzers" />
+    <PackageReference Include="Microsoft.AspNetCore.App.Ref" GeneratePathProperty="true" PrivateAssets="all" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)\analyzers\dotnet\**\*.dll" CopyToOutputDirectory="PreserveNewest" LinkBase="analyzers\netanalyzers" />
     <None Include="$(PkgMicrosoft_CodeAnalysis_CSharp_CodeStyle)\analyzers\dotnet\**\*.dll" CopyToOutputDirectory="PreserveNewest" LinkBase="analyzers\codestyle" />
+    <!-- dotnet\**\*.dll would include localized resources, only use top-level analyzers (App.Analyzers, Components.Analyzers). -->
+    <None Include="$(PkgMicrosoft_AspNetCore_App_Ref)\analyzers\dotnet\cs\*.dll" CopyToOutputDirectory="PreserveNewest" LinkBase="analyzers\aspnetcore" />
   </ItemGroup>
 </Project>

--- a/src/Accord.Services/Diagnostics/diagnostics.json
+++ b/src/Accord.Services/Diagnostics/diagnostics.json
@@ -1,5 +1,285 @@
 [
   {
+    "code": "ASP0003",
+    "message": "Do not use model binding attributes with route handlers",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0004",
+    "message": "Do not use action results with route handlers",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0005",
+    "message": "Do not place attribute on method called by route handler lambda",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0006",
+    "message": "Do not use non-literal sequence numbers",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0007",
+    "message": "Route parameter and argument optionality is mismatched",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0008",
+    "message": "Do not use ConfigureWebHost with WebApplicationBuilder.Host",
+    "severity": "Error",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0009",
+    "message": "Do not use Configure with WebApplicationBuilder.WebHost",
+    "severity": "Error",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0010",
+    "message": "Do not use UseStartup with WebApplicationBuilder.WebHost",
+    "severity": "Error",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0011",
+    "message": "Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0012",
+    "message": "Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0013",
+    "message": "Suggest switching from using Configure methods to WebApplicationBuilder.Configuration",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0014",
+    "message": "Suggest using top level route registrations",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0015",
+    "message": "Suggest using IHeaderDictionary properties",
+    "severity": "Info",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0016",
+    "message": "Do not return a value from RequestDelegate",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0017",
+    "message": "Invalid route pattern",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0018",
+    "message": "Unused route parameter",
+    "severity": "Info",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0019",
+    "message": "Suggest using IHeaderDictionary.Append or the indexer",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0020",
+    "message": "Complex types referenced by route parameters must be parsable",
+    "severity": "Error",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0021",
+    "message": "When implementing BindAsync(...) method, the return type must be ValueTask\u003CT\u003E",
+    "severity": "Error",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0022",
+    "message": "Route conflict detected between route handlers",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0023",
+    "message": "Route conflict detected between controller actions",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0024",
+    "message": "Route handler has multiple parameters with the [FromBody] attribute",
+    "severity": "Error",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0025",
+    "message": "Use AddAuthorizationBuilder",
+    "severity": "Info",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0026",
+    "message": "[Authorize] overridden by [AllowAnonymous] from farther away",
+    "severity": "Warning",
+    "category": "Security",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0027",
+    "message": "Unnecessary public Program class declaration",
+    "severity": "Info",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "ASP0028",
+    "message": "Consider using ListenAnyIP() instead of Listen(IPAddress.Any)",
+    "severity": "Info",
+    "category": "Usage",
+    "url": "https://aka.ms/aspnet/analyzers",
+    "description": null
+  },
+  {
+    "code": "BL0001",
+    "message": "Component parameter should have public setters.",
+    "severity": "Error",
+    "category": "Encapsulation",
+    "url": null,
+    "description": "Component parameters should have public setters."
+  },
+  {
+    "code": "BL0002",
+    "message": "Component has multiple CaptureUnmatchedValues parameters",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": "Components may only define a single parameter with CaptureUnmatchedValues."
+  },
+  {
+    "code": "BL0003",
+    "message": "Component parameter with CaptureUnmatchedValues has the wrong type",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": "Component parameters with CaptureUnmatchedValues must be a correct type."
+  },
+  {
+    "code": "BL0004",
+    "message": "Component parameter should be public.",
+    "severity": "Error",
+    "category": "Encapsulation",
+    "url": null,
+    "description": "Component parameters should be public."
+  },
+  {
+    "code": "BL0005",
+    "message": "Component parameter should not be set outside of its component.",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": "Component parameters should not be set outside of their declared component. Doing so may result in unexpected behavior at runtime."
+  },
+  {
+    "code": "BL0006",
+    "message": "Do not use RenderTree types",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": "The types in \u0027Microsoft.AspNetCore.Components.RenderTree\u0027 are not recommended for use outside of the Blazor framework. These  type definitions will change in future releases."
+  },
+  {
+    "code": "BL0007",
+    "message": "Component parameters should be auto properties",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": null
+  },
+  {
+    "code": "BL0008",
+    "message": "Property with [SupplyParameterFromForm] should not have initializer",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": "The value of a property decorated with [SupplyParameterFromForm] and initialized with a property initializer can be overwritten with null when the component receives parameters. To ensure the initialized value is not overwritten, move the initialization to a component lifecycle method like OnInitialized or OnInitializedAsync"
+  },
+  {
+    "code": "BL0009",
+    "message": "Property with [PersistentState] should not have initializer",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": "The value of a property decorated with [PersistentState] and initialized with a property initializer can be overwritten when the component receives parameters. To ensure the initialized value is not overwritten, move the initialization to a component lifecycle method like OnInitialized or OnInitializedAsync"
+  },
+  {
     "code": "CA1000",
     "message": "Do not declare static members on generic types",
     "severity": "Hidden",

--- a/src/Accord.Services/Diagnostics/diagnostics.json
+++ b/src/Accord.Services/Diagnostics/diagnostics.json
@@ -1,5 +1,53 @@
 [
   {
+    "code": "API1000",
+    "message": "Action returns undeclared status code",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": null
+  },
+  {
+    "code": "API1001",
+    "message": "Action returns undeclared success result",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": null
+  },
+  {
+    "code": "API1002",
+    "message": "Action documents status code that is not returned",
+    "severity": "Info",
+    "category": "Usage",
+    "url": null,
+    "description": null
+  },
+  {
+    "code": "API1003",
+    "message": "Action methods on ApiController instances do not require explicit model validation check",
+    "severity": "Info",
+    "category": "Usage",
+    "url": null,
+    "description": null
+  },
+  {
+    "code": "ASP0000",
+    "message": "Do not call \u0027IServiceCollection.BuildServiceProvider\u0027 in \u0027ConfigureServices\u0027",
+    "severity": "Warning",
+    "category": "Design",
+    "url": "https://aka.ms/AA5k895",
+    "description": null
+  },
+  {
+    "code": "ASP0001",
+    "message": "Authorization middleware is incorrectly configured",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/AA64fv1",
+    "description": null
+  },
+  {
     "code": "ASP0003",
     "message": "Do not use model binding attributes with route handlers",
     "severity": "Warning",
@@ -18981,6 +19029,62 @@
     "severity": "Hidden",
     "category": "Style",
     "url": "https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006",
+    "description": null
+  },
+  {
+    "code": "MVC1000",
+    "message": "Use of IHtmlHelper.{0} should be avoided",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": null
+  },
+  {
+    "code": "MVC1001",
+    "message": "Filters cannot be applied to page handler methods",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": null
+  },
+  {
+    "code": "MVC1002",
+    "message": "Route attributes cannot be applied to page handler methods",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": null
+  },
+  {
+    "code": "MVC1003",
+    "message": "Route attributes cannot be applied to page models",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": null,
+    "description": null
+  },
+  {
+    "code": "MVC1004",
+    "message": "Rename model bound parameter",
+    "severity": "Warning",
+    "category": "Naming",
+    "url": "https://aka.ms/AA20pbc",
+    "description": null
+  },
+  {
+    "code": "MVC1005",
+    "message": "Cannot use UseMvc with Endpoint Routing",
+    "severity": "Warning",
+    "category": "Usage",
+    "url": "https://aka.ms/YJggeFn",
+    "description": null
+  },
+  {
+    "code": "MVC1006",
+    "message": "Methods containing TagHelpers must be async and return Task",
+    "severity": "Error",
+    "category": "Usage",
+    "url": null,
     "description": null
   }
 ]


### PR DESCRIPTION
Adds `API*`, `ASP*`, `BL*`, and `MVC*` diagnostics to `/lookup`.